### PR TITLE
Refactoring and fixes to anynomus export

### DIFF
--- a/src/fi/hut/soberit/agilefant/db/export/DbBackupStreamGenerator.java
+++ b/src/fi/hut/soberit/agilefant/db/export/DbBackupStreamGenerator.java
@@ -2,6 +2,7 @@ package fi.hut.soberit.agilefant.db.export;
 
 import java.io.BufferedReader;
 import java.util.ArrayList;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -90,10 +91,8 @@ public class DbBackupStreamGenerator {
             ZipOutputStream outzip = new ZipOutputStream(zippedDbOutputStream);
             int len;
             if (anonymouse==true) {
-                Sqlfilecontentgenerator sqlscript = new Sqlfilecontentgenerator();
                 outzip.putNextEntry(new ZipEntry("importscript.sql"));
-                               InputStream inscript = sqlscript.getScriptByteStream();
-                 
+                InputStream inscript = new ByteArrayInputStream(Sqlfilecontentgenerator.generateSqlScript().getBytes("UTF-8"));
                 while ((len = inscript.read()) != -1) {
                     outzip.write(len);                
                 }


### PR DESCRIPTION
In practice these are not fatal problems, but memory leaks are always nasty.
- Fixed Connection, PreparedStatement and ResultSet leaks
- Force UTF-8 encoding (previously used platform encoding).
  In practice this doesn't matter but generally it's
  extremely important to always define an encoding when
  converting between bytes and strings
- Removed useless state and converted code to static functions.
  In theory the database connection info could be injected
  with Spring and it would then make sense to use a normal
  object, but in this case it's simpler to use a static function
  and no object state at all.
