### PR TITLE
Fixed "enlarge"-link on burndown charts

### DIFF
--- a/conf/classes/struts.xml
+++ b/conf/classes/struts.xml
@@ -348,6 +348,14 @@
 			</result>
 		</action>
 
+		<action name="drawCustomIterationBurndown" method="getCustomIterationBurndown"
+			class="chartAction">
+			<result name="success" type="stream">
+				<param name="contentType">image/png</param>
+				<param name="inputName">inputStream</param>
+			</result>
+		</action>
+
 		<action name="ROdrawCustomIterationBurndownByToken" method="getCustomIterationBurndownByToken"
 			class="chartAction">
 			<result name="success" type="stream">


### PR DESCRIPTION
- It seems that this action was removed by accident when
  read-only iteration changes were done
- Fixes enlarge link on burndown charts
