### PR TITLE
Story 958: Missing backlog syndrome bug: Clicking on 'Backlogs' tab when no products or standalone iterations that the user has access to throws infinite recursion exception

### DIFF
--- a/conf/classes/struts.xml
+++ b/conf/classes/struts.xml
@@ -86,16 +86,19 @@
 		</action>
 
 		<action name="contextView" class="contextViewAction">
-			<result name="success_backlog" type="redirectAction">
+			<result name="success_id_backlog" type="redirectAction">
 				<param name="actionName">editBacklog</param>
 				<param name="backlogId">${contextObjectId}</param>
 			</result>
 
 			<result name="success_portfolio" type="redirectAction">
 				<param name="actionName">portlets</param>
-				<param name="collectionId">${contextObjectId}</param>
 			</result>
 
+			<result name="success_id_portfolio" type="redirectAction">
+				<param name="actionName">portlets</param>
+				<param name="collectionId">${contextObjectId}</param>
+			</result>
 
 			<result name="success_dailyWork" type="redirectAction">
 				<param name="actionName">dailyWork</param>
@@ -121,6 +124,9 @@
 
 			<result name="success_noContext" type="redirectAction">
 				<param name="actionName">loginContext</param>
+			</result>
+			<result name="success_backlog" type="redirectAction">
+				<param name="actionName">selectBacklog</param>
 			</result>
 			<result name="success_" type="redirectAction">
 				<param name="actionName">selectBacklog</param>

--- a/src/fi/hut/soberit/agilefant/web/ContextViewAction.java
+++ b/src/fi/hut/soberit/agilefant/web/ContextViewAction.java
@@ -48,8 +48,12 @@ public class ContextViewAction extends ActionSupport implements SessionAware {
             }
         }
         contextObjectId = (Integer)session.get(ContextAware.CONTEXT_OBJECT_ID_AFFIX + contextName);
-        
-        return "success_" + contextName;
+
+        if (contextObjectId == null) {
+          return "success_" + contextName;
+        } else {
+          return "success_id_" + contextName;
+        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
- Fixes exception that is thrown when Backlogs-button is clicked
  with no backlogs
