### PR TITLE
Make NotificationEventListener work in Hibernate 4

### DIFF
--- a/webapp/src/main/java/fi/hut/soberit/agilefant/db/hibernate/notification/HibernateEventWiring.java
+++ b/webapp/src/main/java/fi/hut/soberit/agilefant/db/hibernate/notification/HibernateEventWiring.java
@@ -1,0 +1,28 @@
+package fi.hut.soberit.agilefant.db.hibernate.notification;
+
+import javax.annotation.PostConstruct;
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HibernateEventWiring {
+
+    @Autowired
+    private SessionFactory sessionFactory;
+
+    private NotificationEventListener listener;
+
+    @PostConstruct
+    public void registerListeners() {
+        listener = new NotificationEventListener();
+        EventListenerRegistry registry = ((SessionFactoryImplementor) sessionFactory).getServiceRegistry().getService(
+        EventListenerRegistry.class);
+        registry.getEventListenerGroup(EventType.POST_INSERT).appendListener(listener);
+        registry.getEventListenerGroup(EventType.POST_UPDATE).appendListener(listener);
+        registry.getEventListenerGroup(EventType.POST_DELETE).appendListener(listener);
+    }
+}

--- a/webapp/src/main/webapp/WEB-INF/hibernate.cfg.xml
+++ b/webapp/src/main/webapp/WEB-INF/hibernate.cfg.xml
@@ -40,15 +40,5 @@ won't map all the package classes
 <mapping class="fi.hut.soberit.agilefant.model.AgilefantWidget" />
 <mapping class="fi.hut.soberit.agilefant.model.WidgetCollection" />
 <mapping class="fi.hut.soberit.agilefant.model.StoryAccess" />
-
-<event type="post-insert">
-<listener class="fi.hut.soberit.agilefant.db.hibernate.notification.NotificationEventListener" />
-</event>
-<event type="post-update">
-<listener class="fi.hut.soberit.agilefant.db.hibernate.notification.NotificationEventListener" />
-</event>
-<event type="post-delete">
-<listener class="fi.hut.soberit.agilefant.db.hibernate.notification.NotificationEventListener" />
-</event>
 </session-factory>
 </hibernate-configuration>


### PR DESCRIPTION
Hibernate 4 no longer register event listeners from `hibernate.cfg.xml`.
We have to write code to register event listeners.
