### PR TITLE
Update Bubble.js, minWidth as percentage of document width

### DIFF
--- a/webapp/src/main/webapp/static/js/dynamics/view/Bubble.js
+++ b/webapp/src/main/webapp/static/js/dynamics/view/Bubble.js
@@ -10,7 +10,7 @@ var Bubble = function Bubble(referenceElement, options) {
     title:     null,
     offsetX:   100,
     offsetY:   35,
-    minWidth:  400,
+    minWidth:  $(document).width() * 0.6,
     minHeight: 80,
     zIndex:    800,
     maxWidth:  null,


### PR DESCRIPTION
Bubble width is too narrow on some screens. Make it a percentage of the document width.
