### PR TITLE
Fixing the 'Invalid tld file' error in tomcat.

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/tags/structure/createNewMenu.tag
+++ b/webapp/src/main/webapp/WEB-INF/tags/structure/createNewMenu.tag
@@ -1,7 +1,7 @@
 <%@tag description="Create new -menu"%>
 
-<%@taglib uri="../../tlds/aef_structure.tld" prefix="struct" %>
-<%@taglib uri="../../tlds/aef.tld" prefix="aef" %>
+<%@taglib uri="/WEB-INF/tlds/aef_structure.tld" prefix="struct" %>
+<%@taglib uri="/WEB-INF/tlds/aef.tld" prefix="aef" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@taglib uri="/struts-tags" prefix="ww" %>
 

--- a/webapp/src/main/webapp/WEB-INF/tags/structure/defaultRightHeader.tag
+++ b/webapp/src/main/webapp/WEB-INF/tags/structure/defaultRightHeader.tag
@@ -1,7 +1,7 @@
 <%@tag description="Logout div" %>
 
-<%@taglib uri="../../tlds/aef_structure.tld" prefix="struct" %>
-<%@taglib uri="../../tlds/aef.tld" prefix="aef" %>
+<%@taglib uri="/WEB-INF/tlds/aef_structure.tld" prefix="struct" %>
+<%@taglib uri="/WEB-INF/tlds/aef.tld" prefix="aef" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@taglib uri="/struts-tags" prefix="ww" %>
 

--- a/webapp/src/main/webapp/WEB-INF/tags/structure/structure.tag
+++ b/webapp/src/main/webapp/WEB-INF/tags/structure/structure.tag
@@ -1,6 +1,6 @@
 <%@tag description="Wrapper for the Agilefant html structure" %>
 
-<%@taglib uri="../../tlds/aef_structure.tld" prefix="struct" %>
+<%@taglib uri="/WEB-INF/tlds/aef_structure.tld" prefix="struct" %>
 <%@taglib uri="/WEB-INF/tlds/aef.tld" prefix="aef" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@taglib uri="/struts-tags" prefix="ww" %>


### PR DESCRIPTION
These changes fix the "Invalid tld file' error happening in tomcat after version 7.0.70/8.0.36/8.5.3 (see https://bz.apache.org/bugzilla/show_bug.cgi?id=59654).

The error mentions "JSP 2.2 specification section 7.3.1" because this error arises from the tag library descriptor (tld) files being referenced via a relative path in the tag files. To elaborate: the tags are referencing the tld files via a relative path (../../tlds). The JSP 2.2 spec says the tld files cannot be under /WEB-INF/tags, but with the relative path, they have links like /WEB-INF/tags/structure/../../tlds/... One could reasonably argue that tomcat isn't checking the path properly, but this is an easy fix.